### PR TITLE
Loading cdnowElog.csv failed with dc.ReadLines with the idx arguments

### DIFF
--- a/BTYD_trial.R
+++ b/BTYD_trial.R
@@ -6,8 +6,10 @@ library(ggplot2)
 #==== Parate/NBD , BG/NBD, Gamma-Gamma ====
 ## prep
 # load data, and tidy up
-cdnowElog <- system.file("data/cdnowElog.csv", package="BTYD")
-elog <- dc.ReadLines(cdnowElog, cust.idx = 2, date.idx = 3, sales.idx = 5); glimpse(elog)
+# Create event log from file "cdnowElog.csv", which has
+# customer IDs in the second column, dates in the third column, and
+# sales numbers in the fifth column.
+elog <- dc.ReadLines(system.file("data/cdnowElog.csv", package="BTYD"),2,3,5); glimpse(elog)
 elog$date <- as.Date(elog$date, "%Y%m%d")
 # only one tran per cust per day w/ the total sum of their spending for the day
 elog <- dc.MergeTransactionsOnSameDate(elog)


### PR DESCRIPTION
dc.ReadLines failed with following error:
> #==== Parate/NBD , BG/NBD, Gamma-Gamma ====
> ## prep
> # load data, and tidy up
> cdnowElog <- system.file("./Library/R/3.6/library/BTYD/data/cdnowElog.csv", package="BTYD")
> elog <- dc.ReadLines(cdnowElog, cust.idx = 2, date.idx = 3, sales.idx = 5); glimpse(elog)
Started reading file. Progress:
 rep("", n.lines) でエラー:  'times' 引数が不正です 

Seeing the latest BTYD version below, we should provide the arguments with column numbers.
https://www.rdocumentation.org/packages/BTYD/versions/2.4.2